### PR TITLE
improve makefile portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -429,7 +429,7 @@ $(BUILD_INFO_FILE): $(OBJECTS)
 	@echo "-- Build file build_info.c --"
 	@echo '#include "build_info.h"'                            > $(BUILD_INFO_FILE)
 	@echo ''                                                   >> $(BUILD_INFO_FILE)
-	@printf 'const char uc_fw_vers_commit_id[] = \"'           >> $(BUILD_INFO_FILE)
+	@printf 'const char uc_fw_vers_commit_id[] = "'           >> $(BUILD_INFO_FILE)
 	@printf '$(current_repo_commit)'                          >> $(BUILD_INFO_FILE)
 	@echo "!$(current_repo_status)!"
 	@if [ -n "$(current_repo_status)" ]; then                                         \

--- a/Makefile
+++ b/Makefile
@@ -429,19 +429,19 @@ $(BUILD_INFO_FILE): $(OBJECTS)
 	@echo "-- Build file build_info.c --"
 	@echo '#include "build_info.h"'                            > $(BUILD_INFO_FILE)
 	@echo ''                                                   >> $(BUILD_INFO_FILE)
-	@echo -n 'const char uc_fw_vers_commit_id[] = "'           >> $(BUILD_INFO_FILE)
-	@echo -n '$(current_repo_commit)'                          >> $(BUILD_INFO_FILE)
+	@printf 'const char uc_fw_vers_commit_id[] = \"'           >> $(BUILD_INFO_FILE)
+	@printf '$(current_repo_commit)'                          >> $(BUILD_INFO_FILE)
 	@echo "!$(current_repo_status)!"
 	@if [ -n "$(current_repo_status)" ]; then                                         \
-		echo -n '*'                                        >> $(BUILD_INFO_FILE); \
+		printf '*'                                        >> $(BUILD_INFO_FILE); \
 	fi
 	@if [ -n "$(BUILD_VERSION)" ]; then                                               \
-		echo -n '_$(BUILD_VERSION)'                        >> $(BUILD_INFO_FILE); \
+		printf '_$(BUILD_VERSION)'                        >> $(BUILD_INFO_FILE); \
 	fi
 	@if [ -n "$(LIB_VERSIONS)" ]; then                                               \
-		echo -n ',$(LIB_VERSIONS)'                        >> $(BUILD_INFO_FILE); \
+		printf ',$(LIB_VERSIONS)'                        >> $(BUILD_INFO_FILE); \
 	fi
-	@echo -n ',$(BUILD_DATE)'                                  >> $(BUILD_INFO_FILE)
+	@printf ',$(BUILD_DATE)'                                  >> $(BUILD_INFO_FILE)
 	@echo '";'                                                 >> $(BUILD_INFO_FILE)
 
 


### PR DESCRIPTION
Generates `build_info.c` with `printf` instead of `echo -n`. This improves portability, allowing image to be built via `make` on Mac OS X as well. Issue described [here](https://stackoverflow.com/questions/11675070/makefile-echo-n-not-working).